### PR TITLE
Added 'Hex' as an explicit value in 'Encoding' enum and updated unit tests

### DIFF
--- a/csharp-password-hash/csharp-password-hash.Test/PasswordHashTest.cs
+++ b/csharp-password-hash/csharp-password-hash.Test/PasswordHashTest.cs
@@ -32,6 +32,66 @@ namespace CSharpPasswordHash.Test
 
             [Theory]
             [ClassData(typeof(TestDataGenerator))]
+            public void Correct_Password_Should_Match_When_Encoded_Base64(HashingAlgo hashingAlgo)
+            {
+                var hashConfig = new HashingConfig
+                {
+                    GenratePerPasswordSalt = true,
+                    GlobalSalt = null,
+                    SaltedPasswordFormat = SaltedPasswordFormat,
+                    HashingAlgo = hashingAlgo,
+                    PasswordHashEncodingType = EncodingType.Base64
+                };
+
+                var passwordHashing = new PasswordHashing();
+                var hash = passwordHashing.GetHash(CorrectPassword, hashConfig);
+                var match = passwordHashing.CheckPassword(hash, hashConfig, CorrectPassword);
+
+                Assert.True(match);
+            }
+
+            [Theory]
+            [ClassData(typeof(TestDataGenerator))]
+            public void Correct_Password_Should_Match_When_Encoded_Hex(HashingAlgo hashingAlgo)
+            {
+                var hashConfig = new HashingConfig
+                {
+                    GenratePerPasswordSalt = true,
+                    GlobalSalt = null,
+                    SaltedPasswordFormat = SaltedPasswordFormat,
+                    HashingAlgo = hashingAlgo,
+                    PasswordHashEncodingType = EncodingType.Hex
+                };
+
+                var passwordHashing = new PasswordHashing();
+                var hash = passwordHashing.GetHash(CorrectPassword, hashConfig);
+                var match = passwordHashing.CheckPassword(hash, hashConfig, CorrectPassword);
+
+                Assert.True(match);
+            }
+
+            [Theory]
+            [ClassData(typeof(TestDataGenerator))]
+            public void Correct_Password_Should_Match_When_Encoded_Utf8(HashingAlgo hashingAlgo)
+            {
+                var hashConfig = new HashingConfig
+                {
+                    GenratePerPasswordSalt = true,
+                    GlobalSalt = null,
+                    SaltedPasswordFormat = SaltedPasswordFormat,
+                    HashingAlgo = hashingAlgo,
+                    PasswordHashEncodingType = EncodingType.UTF8
+                };
+
+                var passwordHashing = new PasswordHashing();
+                var hash = passwordHashing.GetHash(CorrectPassword, hashConfig);
+                var match = passwordHashing.CheckPassword(hash, hashConfig, CorrectPassword);
+
+                Assert.True(match);
+            }
+
+            [Theory]
+            [ClassData(typeof(TestDataGenerator))]
             public void Wrong_Password_Should_Not_Match(HashingAlgo hashingAlgo)
             {
                 var hashConfig = new HashingConfig
@@ -46,6 +106,35 @@ namespace CSharpPasswordHash.Test
                 var passwordHashing = new PasswordHashing();
                 var hash = passwordHashing.GetHash(CorrectPassword, hashConfig);
                 var match = passwordHashing.CheckPassword(hash, hashConfig, "wrongPassword");
+
+                Assert.False(match);
+            }
+
+            [Theory]
+            [ClassData(typeof(TestDataGenerator))]
+            public void Correct_Password_Wrong_Encoding_Should_Not_Match(HashingAlgo hashingAlgo)
+            {
+                var originalHashConfig = new HashingConfig
+                {
+                    GenratePerPasswordSalt = true,
+                    GlobalSalt = null,
+                    SaltedPasswordFormat = SaltedPasswordFormat,
+                    HashingAlgo = hashingAlgo,
+                    PasswordHashEncodingType = EncodingType.Hex
+                };
+
+                var mismatchedHashConfig = new HashingConfig
+                {
+                    GenratePerPasswordSalt = true,
+                    GlobalSalt = null,
+                    SaltedPasswordFormat = SaltedPasswordFormat,
+                    HashingAlgo = hashingAlgo,
+                    PasswordHashEncodingType = EncodingType.Base64
+                };
+
+                var passwordHashing = new PasswordHashing();
+                var hash = passwordHashing.GetHash(CorrectPassword, originalHashConfig);
+                var match = passwordHashing.CheckPassword(hash, mismatchedHashConfig, CorrectPassword);
 
                 Assert.False(match);
             }

--- a/csharp-password-hash/csharp-password-hash/EncodingType.cs
+++ b/csharp-password-hash/csharp-password-hash/EncodingType.cs
@@ -4,6 +4,7 @@
     {
         Default = 0,
         Base64 = 1,
-        UTF8 = 2
+        UTF8 = 2,
+        Hex = 3
     }
 }

--- a/csharp-password-hash/csharp-password-hash/Hashing.cs
+++ b/csharp-password-hash/csharp-password-hash/Hashing.cs
@@ -32,6 +32,7 @@ namespace CSharpPasswordHash
             switch (encodingType)
             {
                 case EncodingType.Default:
+                case EncodingType.Hex:
                     return ConvertToHex(hashBytes);
                 case EncodingType.Base64:
                     return Convert.ToBase64String(hashBytes);
@@ -82,6 +83,7 @@ namespace CSharpPasswordHash
             switch (encodingType)
             {
                 case EncodingType.Default:
+                case EncodingType.Hex:
                     return ConvertToHex(hashBytes);
                 case EncodingType.Base64:
                     return Convert.ToBase64String(hashBytes);
@@ -110,6 +112,7 @@ namespace CSharpPasswordHash
             switch (encodingType)
             {
                 case EncodingType.Default:
+                case EncodingType.Hex:
                     return ConvertToHex(hashBytes);
                 case EncodingType.Base64:
                     return Convert.ToBase64String(hashBytes);


### PR DESCRIPTION
This addresses #4 including some new unit test coverage to coverage existing code (e.g. where encoding of the original and the second hash aren't compatible).