### PR TITLE
Fix HMAC Encoding and simplify calls

### DIFF
--- a/csharp-password-hash/csharp-password-hash.Test/TestHashDataGenerator.cs
+++ b/csharp-password-hash/csharp-password-hash.Test/TestHashDataGenerator.cs
@@ -17,8 +17,8 @@ namespace CSharpPasswordHash.Test
              */
             new object[] { HashingAlgo.SHA1, "ZmUzODBmOTg0NWZkM2NmNGQ5YjgzNDIyOTEzYTBjNTZmZjUxZWYyZQ=="},
             new object[] { HashingAlgo.SHA256, "OGU1MDgzMDlkODUxOTQ4MjZkZDkyY2JhODA5YTc5MzI5OTkwNWRlMTY0YmU0ZjVhN2FhNTIzMmM1ZmZkOTg0NQ=="},
-            new object[] { HashingAlgo.HMAC_SHA1, "77+9TEcO77+9NWTvv70h77+9fO+/vTIj77+977+9B++/vTIr"},
-            new object[] { HashingAlgo.HMAC_SHA256, "Le+/vS7vv71k77+977+9JO+/vQBI77+9Pu+/ve+/vTvcre+/vRnvv73vv70GBBbvv71IHu+/vVHvv73vv70="},
+            new object[] { HashingAlgo.HMAC_SHA1, "YjY0YzQ3MGVjMzM1NjRmOTIxZGE3Y2NkMzIyM2E3ODAwNzk3MzIyYg=="},
+            new object[] { HashingAlgo.HMAC_SHA256, "MmQ4YjJlYjE2NGZkODQyNDg2MDA0OGU2M2VjZGU3M2JkY2FkOGYxOThlY2UwNjA0MTZiODQ4MWVlODUxYmFhNg=="},
             new object[] { HashingAlgo.MD5, "OTIzZDg5Y2RlOGM0MDRhMGYxODI0NzRhYmI0ZGRmYWQ=" }
         };
 


### PR DESCRIPTION
The Test values had to change, since the expected values were generated using UTF8String instead of the real default Hex because HMAC returned wrong default encoding.

Refactoring also showed, that MD5 only hashes ASCII - Separate Issue