### PR TITLE
Fix spelling of `GeneratePerPasswordSalt` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,21 @@ var userObject = new User
   Password = "Test#11"
 };
 ```
-### Example 1 - Create HashConfig object (When GenratePerPasswordSalt is true)
+### Example 1 - Create HashConfig object (When GeneratePerPasswordSalt is true)
 ```C#
 //Create HashConfig object and set below properties
 var hashConfig = new HashingConfig
 {
-  GenratePerPasswordSalt = true, // This property is used when we have generate different password salt
+  GeneratePerPasswordSalt = true, // This property is used when we have generate different password salt
   GlobalSalt = null, // This is used when we have to use the same salt for every password
   SaltedPasswordFormat = "#PasswordPlaceHolder#--#SaltPlaceHolder#",// Format which will be used in salted password 
   HashingAlgo = HashingAlgo.MD5, // Hashing algo which we want to use
   PasswordHashEncodingType = EncodingType.Default // Encoding type for password hashing
 };
 ```
-### Check password (When GenratePerPasswordSalt is true)
+### Check password (When GeneratePerPasswordSalt is true)
 ```C#
-//Combine the user object and HashConfig object (When GenratePerPasswordSalt is true)
+//Combine the user object and HashConfig object (When GeneratePerPasswordSalt is true)
 //Create method to check password
 public void ValidatePassword()
 {
@@ -63,7 +63,7 @@ public void ValidatePassword()
   };
   var hashConfig = new HashingConfig
   {
-    GenratePerPasswordSalt = true,
+    GeneratePerPasswordSalt = true,
     GlobalSalt = null,
     SaltedPasswordFormat = "#PasswordPlaceHolder#--#SaltPlaceHolder#",
     HashingAlgo = HashingAlgo.MD5,
@@ -75,22 +75,22 @@ public void ValidatePassword()
 }
 ```
 
-### Example 2 - Create HashConfig object (When GenratePerPasswordSalt is false)
+### Example 2 - Create HashConfig object (When GeneratePerPasswordSalt is false)
 ```C#
 //In that case we have to set the GlobalSalt property
 //Create HashConfig object and set below properties
 var hashConfig = new HashingConfig
 {
-  GenratePerPasswordSalt = false, \
+  GeneratePerPasswordSalt = false, \
   GlobalSalt = SecureSalt, 
   SaltedPasswordFormat = "#PasswordPlaceHolder#--#SaltPlaceHolder#",
   HashingAlgo = HashingAlgo.MD5, 
   PasswordHashEncodingType = EncodingType.Default 
 };
 ```
-### Check password (When GenratePerPasswordSalt is false)
+### Check password (When GeneratePerPasswordSalt is false)
 ```C#
-//Combine the user object and HashConfig object (When GenratePerPasswordSalt is false)
+//Combine the user object and HashConfig object (When GeneratePerPasswordSalt is false)
 //Create method to check password
 public void ValidatePassword()
 {
@@ -101,7 +101,7 @@ public void ValidatePassword()
   };
   var hashConfig = new HashingConfig
   {
-    GenratePerPasswordSalt = false,
+    GeneratePerPasswordSalt = false,
     GlobalSalt = "SecureSalt",
     SaltedPasswordFormat = "#PasswordPlaceHolder#--#SaltPlaceHolder#",
     HashingAlgo = HashingAlgo.MD5,

--- a/csharp-password-hash/csharp-password-hash.Test/PasswordHashTest.cs
+++ b/csharp-password-hash/csharp-password-hash.Test/PasswordHashTest.cs
@@ -16,7 +16,7 @@ namespace CSharpPasswordHash.Test
             {
                 var hashConfig = new HashingConfig
                 {
-                    GenratePerPasswordSalt = true,
+                    GeneratePerPasswordSalt = true,
                     GlobalSalt = null,
                     SaltedPasswordFormat = SaltedPasswordFormat,
                     HashingAlgo = hashingAlgo,
@@ -36,7 +36,7 @@ namespace CSharpPasswordHash.Test
             {
                 var hashConfig = new HashingConfig
                 {
-                    GenratePerPasswordSalt = true,
+                    GeneratePerPasswordSalt = true,
                     GlobalSalt = null,
                     SaltedPasswordFormat = SaltedPasswordFormat,
                     HashingAlgo = hashingAlgo,
@@ -56,7 +56,7 @@ namespace CSharpPasswordHash.Test
             {
                 var hashConfig = new HashingConfig
                 {
-                    GenratePerPasswordSalt = true,
+                    GeneratePerPasswordSalt = true,
                     GlobalSalt = null,
                     SaltedPasswordFormat = SaltedPasswordFormat,
                     HashingAlgo = hashingAlgo,
@@ -76,7 +76,7 @@ namespace CSharpPasswordHash.Test
             {
                 var hashConfig = new HashingConfig
                 {
-                    GenratePerPasswordSalt = true,
+                    GeneratePerPasswordSalt = true,
                     GlobalSalt = null,
                     SaltedPasswordFormat = SaltedPasswordFormat,
                     HashingAlgo = hashingAlgo,
@@ -96,7 +96,7 @@ namespace CSharpPasswordHash.Test
             {
                 var hashConfig = new HashingConfig
                 {
-                    GenratePerPasswordSalt = true,
+                    GeneratePerPasswordSalt = true,
                     GlobalSalt = null,
                     SaltedPasswordFormat = SaltedPasswordFormat,
                     HashingAlgo = hashingAlgo,
@@ -117,7 +117,7 @@ namespace CSharpPasswordHash.Test
                 Skip.If(hashingAlgo == HashingAlgo.HMAC_SHA1 || hashingAlgo == HashingAlgo.HMAC_SHA256);
                 var originalHashConfig = new HashingConfig
                 {
-                    GenratePerPasswordSalt = true,
+                    GeneratePerPasswordSalt = true,
                     GlobalSalt = null,
                     SaltedPasswordFormat = SaltedPasswordFormat,
                     HashingAlgo = hashingAlgo,
@@ -126,7 +126,7 @@ namespace CSharpPasswordHash.Test
 
                 var mismatchedHashConfig = new HashingConfig
                 {
-                    GenratePerPasswordSalt = true,
+                    GeneratePerPasswordSalt = true,
                     GlobalSalt = null,
                     SaltedPasswordFormat = SaltedPasswordFormat,
                     HashingAlgo = hashingAlgo,
@@ -149,7 +149,7 @@ namespace CSharpPasswordHash.Test
             {
                 var hashConfig = new HashingConfig
                 {
-                    GenratePerPasswordSalt = false,
+                    GeneratePerPasswordSalt = false,
                     GlobalSalt = GlobalSalt,
                     SaltedPasswordFormat = SaltedPasswordFormat,
                     HashingAlgo = hashingAlgo,
@@ -169,7 +169,7 @@ namespace CSharpPasswordHash.Test
             {
                 var hashConfig = new HashingConfig
                 {
-                    GenratePerPasswordSalt = false,
+                    GeneratePerPasswordSalt = false,
                     GlobalSalt = GlobalSalt,
                     SaltedPasswordFormat = SaltedPasswordFormat,
                     HashingAlgo = hashingAlgo,
@@ -192,7 +192,7 @@ namespace CSharpPasswordHash.Test
             {
                 var hashConfig = new HashingConfig
                 {
-                    GenratePerPasswordSalt = false,
+                    GeneratePerPasswordSalt = false,
                     GlobalSalt = GlobalSalt,
                     SaltedPasswordFormat = SaltedPasswordFormat,
                     HashingAlgo = hashingAlgo,
@@ -212,7 +212,7 @@ namespace CSharpPasswordHash.Test
             {
                 var hashConfig = new HashingConfig
                 {
-                    GenratePerPasswordSalt = false,
+                    GeneratePerPasswordSalt = false,
                     GlobalSalt = GlobalSalt,
                     SaltedPasswordFormat = SaltedPasswordFormat,
                     HashingAlgo = hashingAlgo,

--- a/csharp-password-hash/csharp-password-hash.Test/TestHashDataGenerator.cs
+++ b/csharp-password-hash/csharp-password-hash.Test/TestHashDataGenerator.cs
@@ -9,7 +9,7 @@ namespace CSharpPasswordHash.Test
         {
             /* Hash values generated using the following HashingConfig
              {CSharpPasswordHash.HashingConfig}
-	         GenratePerPasswordSalt: false
+	         GeneratePerPasswordSalt: false
 	         GlobalSalt: "SecureSalt"
 	         HashingAlgo: 
 	         PasswordHashEncodingType: CSharpPasswordHash.EncodingType.Default

--- a/csharp-password-hash/csharp-password-hash/HashingConfig.cs
+++ b/csharp-password-hash/csharp-password-hash/HashingConfig.cs
@@ -1,9 +1,13 @@
-﻿namespace CSharpPasswordHash
+﻿using System;
+
+namespace CSharpPasswordHash
 {
     public class HashingConfig
     {
         public HashingAlgo HashingAlgo { get; set; }
-        public bool GenratePerPasswordSalt { get; set; }
+        [ObsoleteAttribute("Use GeneratePerPasswordSalt instead", false)]
+        public bool GenratePerPasswordSalt { get { return GeneratePerPasswordSalt; } set { GeneratePerPasswordSalt = value; } }
+        public bool GeneratePerPasswordSalt { get; set; }
         public string GlobalSalt { get; set; }
 
         public string SaltedPasswordFormat { get; set; }

--- a/csharp-password-hash/csharp-password-hash/PasswordHashing.cs
+++ b/csharp-password-hash/csharp-password-hash/PasswordHashing.cs
@@ -9,7 +9,7 @@ namespace CSharpPasswordHash
         {
             var result = (salt: string.Empty, passwordHash: String.Empty, globalFormattedSalt: string.Empty);
 
-            if (passwordEncryption.GenratePerPasswordSalt)
+            if (passwordEncryption.GeneratePerPasswordSalt)
             {
                 var idx = oldPassword.LastIndexOf(':');
                 if (idx != -1)
@@ -54,7 +54,7 @@ namespace CSharpPasswordHash
 
         public string GetHash(string password, HashingConfig hashConfig)
         {
-            var salt = hashConfig.GenratePerPasswordSalt
+            var salt = hashConfig.GeneratePerPasswordSalt
                 ? Hashing.GenerateSalt()
                     : hashConfig.GlobalSalt;
 
@@ -63,7 +63,7 @@ namespace CSharpPasswordHash
             var passwordHash = Hashing.HashPassword(saltedPassword, salt, hashConfig.HashingAlgo,
                 hashConfig.PasswordHashEncodingType, hashConfig.Pbkdf2Iterations);
 
-            return hashConfig.GenratePerPasswordSalt ? $"{passwordHash}:{salt}" : passwordHash;
+            return hashConfig.GeneratePerPasswordSalt ? $"{passwordHash}:{salt}" : passwordHash;
         }
 
         public HashingConfig GetPossibleConfig(string password, string salt, string saltedPasswordFormat, string inputhash)


### PR DESCRIPTION
Rename incorrectly spelled `GenratePerPasswordSalt` to `GeneratePerPasswordSalt`.
Add obsoleted `GenratePerPasswordSalt` for backward compatibility.
Update examples in README.