### PR TITLE
Add per password salt length configuration

### DIFF
--- a/csharp-password-hash/csharp-password-hash/Hashing.cs
+++ b/csharp-password-hash/csharp-password-hash/Hashing.cs
@@ -111,12 +111,12 @@ namespace CSharpPasswordHash
             };
         }
 
-        public static string GenerateSalt()
+        public static string GenerateSalt(int length)
         {
             const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz";
             var random = new Random((int)DateTime.Now.Ticks & 0x0000FFFF);
             return new string(
-                Enumerable.Repeat(chars, 8)
+                Enumerable.Repeat(chars, length)
                     .Select(s => s[random.Next(s.Length)])
                     .ToArray());
         }

--- a/csharp-password-hash/csharp-password-hash/Hashing.cs
+++ b/csharp-password-hash/csharp-password-hash/Hashing.cs
@@ -116,7 +116,7 @@ namespace CSharpPasswordHash
             const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz";
             var random = new Random((int)DateTime.Now.Ticks & 0x0000FFFF);
             return new string(
-                Enumerable.Repeat(chars, length)
+                Enumerable.Repeat(chars, length == 0 ? 8 : length)
                     .Select(s => s[random.Next(s.Length)])
                     .ToArray());
         }

--- a/csharp-password-hash/csharp-password-hash/HashingConfig.cs
+++ b/csharp-password-hash/csharp-password-hash/HashingConfig.cs
@@ -8,6 +8,7 @@ namespace CSharpPasswordHash
         [ObsoleteAttribute("Use GeneratePerPasswordSalt instead", false)]
         public bool GenratePerPasswordSalt { get { return GeneratePerPasswordSalt; } set { GeneratePerPasswordSalt = value; } }
         public bool GeneratePerPasswordSalt { get; set; }
+        public int PerPasswordSaltLength { get; set; }
         public string GlobalSalt { get; set; }
 
         public string SaltedPasswordFormat { get; set; }

--- a/csharp-password-hash/csharp-password-hash/PasswordHashing.cs
+++ b/csharp-password-hash/csharp-password-hash/PasswordHashing.cs
@@ -55,7 +55,7 @@ namespace CSharpPasswordHash
         public string GetHash(string password, HashingConfig hashConfig)
         {
             var salt = hashConfig.GeneratePerPasswordSalt
-                ? Hashing.GenerateSalt()
+                ? Hashing.GenerateSalt(hashConfig.PerPasswordSaltLength)
                     : hashConfig.GlobalSalt;
 
             var saltedPassword = GetSaltedPassword(password, salt, hashConfig.SaltedPasswordFormat);

--- a/csharp-password-hash/csharp-password-hash/csharp-password-hash.csproj
+++ b/csharp-password-hash/csharp-password-hash/csharp-password-hash.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
     <RootNamespace>CSharpPasswordHash</RootNamespace>
+    <Configurations>Debug;Release;BUAT;PUAT</Configurations>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
To improve the password hash security, hash configuration will allow to configure per password salt length. If not set, per password salt length will use 8 length.